### PR TITLE
fix: join `feedback_user_flags` whether the user is logged in or not

### DIFF
--- a/app/models/houston/feedback/conversation.rb
+++ b/app/models/houston/feedback/conversation.rb
@@ -34,10 +34,9 @@ module Houston
         end
 
         def with_flags_for(user)
-          return all unless user.respond_to?(:id)
           joins(<<-SQL).select("feedback_conversations.*", "flags.read", "flags.signal_strength")
             LEFT OUTER JOIN feedback_user_flags \"flags\"
-            ON flags.conversation_id=feedback_conversations.id AND flags.user_id=#{user.id}
+            ON flags.conversation_id=feedback_conversations.id AND #{user.respond_to?(:id) ? "flags.user_id=#{user.id}" : "1 != 1"}
           SQL
         end
 


### PR DESCRIPTION
So that `ConversationPresenter#optimized_present_all` can refer to `flags` in lines
```
95          q.signalStrength select: Arel.sql("flags.signal_strength")
96          q.read select: Arel.sql("flags.read")
```